### PR TITLE
Releasing v1.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
-# Release Notes
+### v1.0.0-beta.2 (2025-04-10)
+
+- Upgraded to `chargebee-php` version `v4.x.x`.
+- Migrated codebase to be compatible with `chargebee-php v4.x.x`.
+- Updated `minimum-stability` to `beta`.

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,6 @@
             "Chargebee\\Cashier\\Tests\\Fixtures\\": "tests/Fixtures/"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "beta",
     "prefer-stable": true
 }


### PR DESCRIPTION
### v1.0.0-beta.2 (2025-04-10)

- Upgraded to `chargebee-php` version `v4.x.x`.
- Migrated codebase to be compatible with `chargebee-php v4.x.x`.
- Updated `minimum-stability` to `beta`.