### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v1.0.0-beta.2 (2025-04-16)
+
+- Upgraded to `chargebee-php` version `v4.x.x` stable.
+- removed minimum stability tag from the composer.
+
 ### v1.0.0-beta.2 (2025-04-10)
 
 - Upgraded to `chargebee-php` version `v4.x.x`.

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "illuminate/support": "^10.0|^11.0|^12.0",
         "illuminate/database": "^10.0|^11.0|^12.0",
         "moneyphp/money": "^4.0",
-        "chargebee/chargebee-php": "v4.0.0-beta.3"
+        "chargebee/chargebee-php": "v4.0.0"
     },
     "require-dev": {
         "dompdf/dompdf": "^2.0",
@@ -51,6 +51,5 @@
             "Chargebee\\Cashier\\Tests\\Fixtures\\": "tests/Fixtures/"
         }
     },
-    "minimum-stability": "beta",
     "prefer-stable": true
 }

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -24,7 +24,7 @@ final class Cashier
      *
      * @var string
      */
-    public const VERSION = '1.0.0-beta.2';
+    public const VERSION = '1.0.0';
     
     /**
      * The custom currency formatter.


### PR DESCRIPTION
### v1.0.0-beta.2 (2025-04-16)

- Upgraded to `chargebee-php` version `v4.x.x` stable.
- removed minimum stability tag from the composer.
