### PR TITLE
Re-add copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) Taylor Otwell
 Copyright (c) Chargebee
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Hi there. This package obviously seems heavily inspired by Laravel Cashier Stripe. Of course, you're free to fork it and adapt it for other purposes and re-distribute. But as the license says, the original format including the copyright notice should be kept to attribute the original author.

In general, it would have been appreciated if the original package was attributed in the readme. 