### PR TITLE
 Add an .editorconfig for consistent editor formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
This PR introduces a .editorconfig file to enforce consistent code style across different editors and IDEs.

**Configuration highlights:**

- UTF-8 encoding and LF line endings
- 4-space indentation for most files
- 2-space indentation for YAML files
- Final newline insertion
- Trimming of trailing whitespace (except in Markdown)

This helps avoid unnecessary diffs and ensures consistent formatting across contributors.

It is inspired from https://github.com/laravel/framework/blob/12.x/.editorconfig