### PR TITLE
Remove unused StyleCI configuration file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.styleci.yml export-ignore
 CHANGELOG.md export-ignore
 phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,0 @@
-php:
-  preset: laravel
-js: true
-css: true


### PR DESCRIPTION
This PR removes the obsolete `.styleci.yml` configuration file from the project root, as it is no longer in use.

**Additional change:**

* Cleaned up `.gitattributes` to stop excluding the removed file from distribution exports.

---

This helps reduce project clutter and avoids confusion around unused or deprecated tooling.
