### PR TITLE
Releasing v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### v1.0.0-beta.2 (2025-04-16)
+### v1.0.1 (2025-05-16)
+- Bug Fix: Prevented ChargebeeClient instantiation if required config values (`CHARGEBEE_SITE` or `CHARGEBEE_API_KEY`) are missing, avoiding exceptions during package discovery or autoload.
+
+### v1.0.0 (2025-04-16)
 
 - Upgraded to `chargebee-php` version `v4.x.x` stable.
 - removed minimum stability tag from the composer.

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -20,7 +20,9 @@ class CashierServiceProvider extends ServiceProvider
         $this->registerRoutes();
         $this->registerResources();
         $this->registerPublishing();
-        Cashier::configureEnvironment();
+        if (config('cashier.site') && config('cashier.api_key')) {
+            Cashier::configureEnvironment();
+        }
 
         Event::listen(
             WebhookReceived::class,


### PR DESCRIPTION
### v1.0.1 (2025-05-16)
- Bug Fix: Prevented ChargebeeClient instantiation if required config values (`CHARGEBEE_SITE` or `CHARGEBEE_API_KEY`) are missing, avoiding exceptions during package discovery or autoload.
