### PR TITLE
Releasing v1.1.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 /compose-dev.yaml
 /coverage.xml
 /report
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### v1.1.0 (2025-05-19)
+* * * 
+
+- Simplify GitHub Actions using cleaner matrix syntax, #17.
+- Add an .editorconfig for consistent editor formatting, #18.
+- Normalize composer.json using ergebnis/composer-normalize, #19.
+- Remove unused StyleCI configuration file, #20.
+- Add Laravel Pint configuration and format codebase, #21.
+- Bumped up the `chargebee-php` version to `v4.3.0` and updated the testcase accordingly.
+- Added the script `composer lint` to lint the project using pint.
+- Added a dev dependencies `laravel/pint`.
+
 ### v1.0.1 (2025-05-16)
 - Bug Fix: Prevented ChargebeeClient instantiation if required config values (`CHARGEBEE_SITE` or `CHARGEBEE_API_KEY`) are missing, avoiding exceptions during package discovery or autoload.
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
     ],
     "require": {
         "php": "^8.1",
-        "chargebee/chargebee-php": "4.0.0",
+        "chargebee/chargebee-php": "4.3.0",
         "illuminate/database": "^10.0 || ^11.0 || ^12.0",
         "illuminate/support": "^10.0 || ^11.0 || ^12.0",
         "moneyphp/money": "^4.0"
     },
     "require-dev": {
         "dompdf/dompdf": "^2.0",
+        "laravel/pint": "^1.22",
         "orchestra/testbench": "^8.18 || ^9.0",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.4"
@@ -51,5 +52,8 @@
                 "Chargebee\\Cashier\\CashierServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "lint": "pint"
     }
 }

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -26,7 +26,7 @@ final class Cashier
      *
      * @var string
      */
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.1.0';
 
     /**
      * The custom currency formatter.

--- a/tests/Feature/WebhookTest.php
+++ b/tests/Feature/WebhookTest.php
@@ -2,14 +2,12 @@
 
 namespace Chargebee\Cashier\Tests\Feature;
 
-use Chargebee\Actions\ItemPriceActions;
 use Chargebee\Cashier\Cashier;
 use Chargebee\Cashier\Events\WebhookReceived;
 use Chargebee\Cashier\Subscription;
+use Chargebee\Cashier\Tests\Fixtures\ItemPriceActionsFixture;
 use Chargebee\Cashier\Tests\Fixtures\User;
-use Chargebee\ChargebeeClient;
 use Chargebee\Resources\PaymentSource\PaymentSource;
-use Chargebee\Responses\ItemPriceResponse\RetrieveItemPriceResponse;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
@@ -28,26 +26,10 @@ class WebhookTest extends FeatureTestCase
 
         config(['cashier.webhook.username' => 'webhook_username']);
         config(['cashier.webhook.password' => 'webhook_password']);
-
-        $mockItemPriceActions = \Mockery::mock('overload:'.ItemPriceActions::class);
-        $mockItemPriceActions->shouldReceive('retrieve')
-            ->with(\Mockery::type('string'))
-            ->andReturn(RetrieveItemPriceResponse::from([
-                'item_price' => [
-                    'id' => 'abc',
-                    'item_id' => 'product_abc',
-                    'name' => 'Basic Plan',
-                    'currency_code' => 'USD',
-                    'free_quantity' => 0,
-                    'created_at' => time(),
-                    'deleted' => false,
-                    'pricing_model' => 'flat_fee',
-                ],
-            ]));
-
-        $mockChargebeeClient = \Mockery::mock(ChargebeeClient::class)->makePartial();
-        $mockChargebeeClient->shouldReceive('itemPrice')
-            ->andReturn($mockItemPriceActions);
+        $client = Cashier::$chargebeeClient;
+        $spy = \Mockery::mock($client)->makePartial();
+        $spy->shouldReceive('itemPrice')->andReturn(new ItemPriceActionsFixture);
+        Cashier::$chargebeeClient = $spy;
     }
 
     public function test_valid_webhooks_are_authenticated_successfully(): void

--- a/tests/Fixtures/ItemPriceActionsFixture.php
+++ b/tests/Fixtures/ItemPriceActionsFixture.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Chargebee\Cashier\Tests\Fixtures;
+
+use Chargebee\Actions\Contracts\ItemPriceActionsInterface;
+use Chargebee\Responses\ItemPriceResponse\CreateItemPriceResponse;
+use Chargebee\Responses\ItemPriceResponse\DeleteItemPriceResponse;
+use Chargebee\Responses\ItemPriceResponse\FindApplicableItemPricesItemPriceResponse;
+use Chargebee\Responses\ItemPriceResponse\FindApplicableItemsItemPriceResponse;
+use Chargebee\Responses\ItemPriceResponse\ListItemPriceResponse;
+use Chargebee\Responses\ItemPriceResponse\RetrieveItemPriceResponse;
+use Chargebee\Responses\ItemPriceResponse\UpdateItemPriceResponse;
+
+class ItemPriceActionsFixture implements ItemPriceActionsInterface
+{
+    public function findApplicableItems(string $id, array $params = [], array $headers = []): FindApplicableItemsItemPriceResponse
+    {
+        return FindApplicableItemsItemPriceResponse::from([
+            'item_price_id' => $id,
+            'items' => [],
+        ]);
+    }
+
+    public function retrieve(string $id, array $headers = []): RetrieveItemPriceResponse
+    {
+        return RetrieveItemPriceResponse::from([
+            'item_price' => [
+                'id' => 'abc',
+                'item_id' => 'product_abc',
+                'name' => 'Basic Plan',
+                'currency_code' => 'USD',
+                'free_quantity' => 0,
+                'created_at' => time(),
+                'deleted' => false,
+                'pricing_model' => 'flat_fee',
+            ],
+        ]);
+    }
+
+    public function update(string $id, array $params, array $headers = []): UpdateItemPriceResponse
+    {
+        return UpdateItemPriceResponse::from([
+            'item_price' => ['id' => $id, 'updated' => true, 'params' => $params],
+        ]);
+    }
+
+    public function delete(string $id, array $headers = []): DeleteItemPriceResponse
+    {
+        return DeleteItemPriceResponse::from([
+            'item_price' => ['id' => $id, 'deleted' => true],
+        ]);
+    }
+
+    public function findApplicableItemPrices(string $id, array $params = [], array $headers = []): FindApplicableItemPricesItemPriceResponse
+    {
+        return FindApplicableItemPricesItemPriceResponse::from([
+            'item_price_id' => $id,
+            'applicable_prices' => [],
+        ]);
+    }
+
+    public function all(array $params = [], array $headers = []): ListItemPriceResponse
+    {
+        return ListItemPriceResponse::from([
+            'list' => [],
+            'next_offset' => null,
+        ]);
+    }
+
+    public function create(array $params, array $headers = []): CreateItemPriceResponse
+    {
+        return CreateItemPriceResponse::from([
+            'item_price' => ['id' => 'sample_id', 'name' => 'Created Item Price', 'params' => $params],
+        ]);
+    }
+}


### PR DESCRIPTION
### v1.1.0 (2025-05-19)
* * * 

- Simplify GitHub Actions using cleaner matrix syntax, #17.
- Add an .editorconfig for consistent editor formatting, #18.
- Normalize composer.json using ergebnis/composer-normalize, #19.
- Remove unused StyleCI configuration file, #20.
- Add Laravel Pint configuration and format codebase, #21.
- Bumped up the `chargebee-php` version to `v4.3.0` and updated the testcase accordingly.
- Added the script `composer lint` to lint the project using pint.
- Added a dev dependencies `laravel/pint`.