### PR TITLE
Artisan command to create the feature enum class. 

### DIFF
--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Chargebee\Cashier;
 
+use Chargebee\Cashier\Console\FeatureEnumCommand;
 use Chargebee\Cashier\Console\WebhookCommand;
 use Chargebee\Cashier\Contracts\InvoiceRenderer;
 use Chargebee\Cashier\Events\WebhookReceived;
@@ -121,6 +122,7 @@ class CashierServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 WebhookCommand::class,
+                FeatureEnumCommand::class
             ]);
         }
     }

--- a/src/Console/FeatureEnumCommand.php
+++ b/src/Console/FeatureEnumCommand.php
@@ -83,10 +83,17 @@ class FeatureEnumCommand extends Command
     protected function renderEnum(string $namespace, string $class, array $cases): string
     {
         $casesBlock = collect($cases)
-            ->map(fn ($val, $name) => "    case {$name} = '" . addslashes($val) . "';")
+            ->map(fn($val, $name) => "    case {$name} = '" . addslashes($val) . "';")
             ->implode("\n");
 
-        $arrayExport = var_export(array_values($cases), true);
+        // Format the array values with proper indentation
+        $arrayValues = [];
+        $index = 0;
+        foreach ($cases as $value) {
+            $arrayValues[] = "            {$index} => '" . addslashes($value) . "',";
+            $index++;
+        }
+        $arrayValuesBlock = implode("\n", $arrayValues);
 
         return <<<PHP
 <?php
@@ -101,10 +108,11 @@ enum {$class}: string
 
     public static function values(): array
     {
-        return {$arrayExport};
+        return array(
+{$arrayValuesBlock}
+        );
     }
 }
-
 PHP;
     }
 }

--- a/src/Console/FeatureEnumCommand.php
+++ b/src/Console/FeatureEnumCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Chargebee\Cashier\Console;
+
+use Illuminate\Console\Command;
+use Chargebee\Cashier\Cashier;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'cashier:generate-feature-enum')]
+class FeatureEnumCommand extends Command
+{
+    protected $signature = 'cashier:generate-feature-enum
+        {--class=FeaturesMap : The enum class name}
+        {--namespace=App\\Models : The namespace for the enum}
+        {--path=app/Models : Directory to save the enum file}
+        {--force : Overwrite if the file already exists}';
+
+    protected $description = 'Generate a PHP enum of Chargebee features and save it in app/Models';
+
+    public function handle(): int
+    {
+        $class = $this->option('class');
+        $namespace = rtrim($this->option('namespace'), '\\');
+        $path = rtrim($this->option('path'), '/');
+        $filePath = base_path("{$path}/{$class}.php");
+
+        try {
+            $this->components->info("Fetching features from Chargebee…");
+            $result = Cashier::chargebee()->feature()->all();
+
+            $cases = [];
+            foreach ($result->list as $featureList) {
+                $feature = $featureList->feature;
+
+                $caseName = $this->toEnumCase($feature->name);
+                if ($caseName === '') {
+                    $this->warn("Skipping feature with name that cannot be mapped to php enum feature name: '{$feature->name}' \n");
+                    continue;
+                }
+                $caseValue = $feature->id ?? $feature->name;
+
+                if (isset($cases[$caseName])) {
+                    // Avoid duplicate keys
+                    $caseName .= '_' . substr(md5($caseValue), 0, 6);
+                }
+                $cases[$caseName] = $caseValue;
+            }
+
+            if (empty($cases)) {
+                $this->error('No features found.');
+                return self::FAILURE;
+            }
+
+            $php = $this->renderEnum($namespace, $class, $cases);
+
+            if (File::exists($filePath) && !$this->option('force')) {
+                $this->error("File already exists at {$filePath}. Use --force to overwrite.");
+                return self::FAILURE;
+            }
+
+            if (!File::isDirectory(base_path($path))) {
+                File::makeDirectory(base_path($path), 0755, true);
+            }
+
+            File::put($filePath, $php);
+            $this->components->info("✅ Enum generated at {$filePath}");
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error("Failed: " . $e->getMessage());
+            return self::FAILURE;
+        }
+    }
+
+    protected function toEnumCase(string $name): string
+    {
+        $underscored = preg_replace('/[^a-zA-Z0-9]+/', '_', $name);
+        $underscored = preg_replace('/^[0-9]+/', '', $underscored);
+        return strtoupper(trim($underscored, '_'));
+    }
+
+    protected function renderEnum(string $namespace, string $class, array $cases): string
+    {
+        $casesBlock = collect($cases)
+            ->map(fn ($val, $name) => "    case {$name} = '" . addslashes($val) . "';")
+            ->implode("\n");
+
+        $arrayExport = var_export(array_values($cases), true);
+
+        return <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace {$namespace};
+
+enum {$class}: string
+{
+{$casesBlock}
+
+    public static function values(): array
+    {
+        return {$arrayExport};
+    }
+}
+
+PHP;
+    }
+}

--- a/src/Console/FeatureEnumCommand.php
+++ b/src/Console/FeatureEnumCommand.php
@@ -42,7 +42,7 @@ class FeatureEnumCommand extends Command
                         $this->warn("Skipping feature with name that cannot be mapped to php enum feature name: '{$feature->name}' \n");
                         continue;
                     }
-                    $caseValue = $feature->id ?? $feature->name;
+                    $caseValue = $feature->id;
 
                     if (isset($cases[$caseName])) {
                         // Avoid duplicate keys

--- a/tests/Feature/FeatureEnumCommandTest.php
+++ b/tests/Feature/FeatureEnumCommandTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Chargebee\Cashier\Tests\Feature;
+
+use Chargebee\Cashier\Cashier;
+use Chargebee\Cashier\Tests\Fixtures\FeatureActionsFixture;
+use Illuminate\Support\Facades\File;
+
+class FeatureEnumCommandTest extends FeatureTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Mock the Chargebee client
+        $client = Cashier::$chargebeeClient;
+        $spy = \Mockery::mock($client)->makePartial();
+        $spy->shouldReceive('feature')->andReturn(new FeatureActionsFixture());
+        Cashier::$chargebeeClient = $spy;
+
+        File::shouldReceive('exists')->andReturn(false);
+        File::shouldReceive('isDirectory')->andReturn(true);
+        File::shouldReceive('makeDirectory')->never();
+    }
+
+    public function test_generate_feature_enum_should_create_enum_file_with_cases_and_values(): void
+    {
+        $capturedPath = null;
+        $capturedPhp = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPath, &$capturedPhp) {
+                $capturedPath = $path;
+                $capturedPhp = $php;
+                return true;
+            });
+        $this->artisan('cashier:generate-feature-enum', [
+            '--class' => 'FeaturesMap',
+            '--namespace' => 'App\\Models',
+            '--path' => 'app/Models',
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        // Add assertions to verify the captured content
+        $this->assertNotNull($capturedPath);
+        $this->assertNotNull($capturedPhp);
+
+        // Verify the file path
+        $expectedPath = base_path('app/Models/FeaturesMap.php');
+        $this->assertEquals($expectedPath, $capturedPath);
+
+        // Verify the generated PHP contains expected elements
+        $this->assertStringContainsString('namespace App\\Models;', $capturedPhp);
+        $this->assertStringContainsString('enum FeaturesMap: string', $capturedPhp);
+        $this->assertStringContainsString('public static function values(): array', $capturedPhp);
+        $this->assertStringContainsString("case FREE_TRIAL = 'feature_free_trial';", $capturedPhp);
+        $this->assertStringContainsString("case PRIORITY_SUPPORT = 'feature_priority_support';", $capturedPhp);
+    }
+    public function test_should_overwrite_existing_file_when_force_option_is_used(): void
+    {
+        File::shouldReceive('exists')->andReturn(true);
+        File::shouldReceive('put')->once()->andReturn(true);
+
+        $this->artisan('cashier:generate-feature-enum', [
+            '--class' => 'FeaturesMap',
+            '--namespace' => 'App\\Models',
+            '--path' => 'app/Models',
+            '--force' => true,
+        ])->assertExitCode(0);
+    }
+
+    public function test_should_create_directory_when_it_does_not_exist(): void
+    {
+        File::shouldReceive('isDirectory')->andReturn(false);
+        File::shouldReceive('makeDirectory')
+            ->with(base_path('app/Models'), 0755, true)
+            ->andReturn(true);
+        File::shouldReceive('put')->once()->andReturn(true);
+
+        $this->artisan('cashier:generate-feature-enum', [
+            '--class' => 'FeaturesMap',
+            '--namespace' => 'App\\Models',
+            '--path' => 'app/Models',
+            '--force' => true,
+        ])->assertExitCode(0);
+    }
+
+    public function test_should_use_default_options_when_none_provided(): void
+    {
+        $capturedPath = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPath) {
+                $capturedPath = $path;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', ['--force' => true])
+            ->assertExitCode(0);
+
+        $expectedPath = base_path('app/Models/FeaturesMap.php');
+        $this->assertEquals($expectedPath, $capturedPath);
+    }
+
+    public function test_should_handle_custom_class_and_namespace(): void
+    {
+        $capturedPath = null;
+        $capturedPhp = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPath, &$capturedPhp) {
+                $capturedPath = $path;
+                $capturedPhp = $php;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', [
+            '--class' => 'CustomFeatures',
+            '--namespace' => 'App\\Enums',
+            '--path' => 'app/Enums',
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $expectedPath = base_path('app/Enums/CustomFeatures.php');
+        $this->assertEquals($expectedPath, $capturedPath);
+        $this->assertStringContainsString('namespace App\\Enums;', $capturedPhp);
+        $this->assertStringContainsString('enum CustomFeatures: string', $capturedPhp);
+    }
+
+    public function test_should_handle_namespace_with_trailing_backslash(): void
+    {
+        $capturedPhp = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPhp) {
+                $capturedPhp = $php;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', [
+            '--namespace' => 'App\\Models\\',
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $this->assertStringContainsString('namespace App\\Models;', $capturedPhp);
+    }
+
+    public function test_should_handle_path_with_trailing_slash(): void
+    {
+        $capturedPath = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPath) {
+                $capturedPath = $path;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', [
+            '--path' => 'app/Models/',
+            '--force' => true,
+        ])->assertExitCode(0);
+
+        $expectedPath = base_path('app/Models/FeaturesMap.php');
+        $this->assertEquals($expectedPath, $capturedPath);
+    }
+
+
+    public function test_should_skip_features_with_invalid_names(): void
+    {
+        $capturedPhp = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPhp) {
+                $capturedPhp = $php;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', ['--force' => true])
+            ->assertExitCode(0);
+
+        // Should only contain the valid feature
+        $this->assertStringContainsString("case FREE_TRIAL = 'feature_free_trial';", $capturedPhp);
+        $this->assertStringNotContainsString('12121212', $capturedPhp);
+    }
+
+
+    // even though this method is here chargebee itself doesn't allow duplicate feature name as of now.
+    public function test_should_handle_duplicate_case_names(): void
+    {
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPhp) {
+                $capturedPhp = $php;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', ['--force' => true])
+            ->assertExitCode(0);
+
+        // Should contain both features with different case names
+        $this->assertStringContainsString("case PRIORITY_SUPPORT = 'feature_priority_support';", $capturedPhp);
+        // The second one should have a hash suffix to avoid duplication
+        $this->assertMatchesRegularExpression("/case PRIORITY_SUPPORT_[a-f0-9]{6} = 'check_check';/", $capturedPhp);
+    }
+    public function test_should_escape_special_characters_in_values(): void
+    {
+        $capturedPhp = null;
+        File::shouldReceive('put')
+            ->once()
+            ->andReturnUsing(function ($path, $php) use (&$capturedPhp) {
+                $capturedPhp = $php;
+                return true;
+            });
+
+        $this->artisan('cashier:generate-feature-enum', ['--force' => true])
+            ->assertExitCode(0);
+
+        // Should properly escape special characters
+        $this->assertStringContainsString("case MYNAME_ISCASHIER = 'some-uuid';", $capturedPhp);
+    }
+}

--- a/tests/Fixtures/FeatureActionsFixture.php
+++ b/tests/Fixtures/FeatureActionsFixture.php
@@ -14,7 +14,7 @@ use Chargebee\Responses\FeatureResponse\ArchiveFeatureResponse;
 
 class FeatureActionsFixture implements FeatureActionsInterface
 {
-    public array $feature = [
+    public static array $normalFeature = [
         'feature' => [
             'id' => "Dummy-Feature-id",
             'name' => 'Free Trial',
@@ -33,6 +33,113 @@ class FeatureActionsFixture implements FeatureActionsInterface
             'type' => 'limit',
         ],
     ];
+    public array $featureList = [];
+    public array $feature = [];
+    public static array $featureListWithNormalFields = [
+        'list' => [
+            [
+                'feature' => [
+                    'id' => 'feature_free_trial',
+                    'name' => 'Free Trial',
+                    'description' => 'Gives 14 days of free trial access',
+                    'unit' => 'days',
+                    'resource_version' => 1,
+                    'updated_at' => 1690999999,
+                    'created_at' => 1690000000,
+                    'levels' => [],
+                    'status' => 'active',
+                    'type' => 'limit',
+                ],
+            ],
+            [
+                'feature' => [
+                    'id' => 'feature_priority_support',
+                    'name' => 'Priority Support',
+                    'description' => '24/7 support',
+                    'unit' => null,
+                    'resource_version' => 2,
+                    'updated_at' => 1691999999,
+                    'created_at' => 1691000000,
+                    'levels' => [],
+                    'status' => 'archived',
+                    'type' => 'boolean',
+                ],
+            ]
+        ]
+    ];
+
+    public static array $featureListWithInvalidEnumName = [
+        'list' => [
+            [
+                'feature' => [
+                    'id' => 'feature_free_trial',
+                    'name' => 'Free Trial',
+                    'description' => 'Gives 14 days of free trial access',
+                    'unit' => 'days',
+                    'resource_version' => 1,
+                    'updated_at' => 1690999999,
+                    'created_at' => 1690000000,
+                    'levels' => [],
+                    'status' => 'active',
+                    'type' => 'limit',
+                ],
+            ],
+            [
+                'feature' => [
+                    'id' => 'feature_priority_support',
+                    'name' => '999999999',
+                    'description' => '24/7 support',
+                    'unit' => null,
+                    'resource_version' => 2,
+                    'updated_at' => 1691999999,
+                    'created_at' => 1691000000,
+                    'levels' => [],
+                    'status' => 'archived',
+                    'type' => 'boolean',
+                ],
+            ]
+        ]
+    ];
+
+    public static array $featureListWithSpecialCharacterInName = [
+        'list' => [
+            [
+                'feature' => [
+                    'id' => 'feature_free_trial',
+                    'name' => 'Free$$$ Trial',
+                    'description' => 'Gives 14 days of free trial access',
+                    'unit' => 'days',
+                    'resource_version' => 1,
+                    'updated_at' => 1690999999,
+                    'created_at' => 1690000000,
+                    'levels' => [],
+                    'status' => 'active',
+                    'type' => 'limit',
+                ],
+            ],
+            [
+                'feature' => [
+                    'id' => 'feature_priority_support',
+                    'name' => 'Priority$$$ Support',
+                    'description' => '24/7 support',
+                    'unit' => null,
+                    'resource_version' => 2,
+                    'updated_at' => 1691999999,
+                    'created_at' => 1691000000,
+                    'levels' => [],
+                    'status' => 'archived',
+                    'type' => 'boolean',
+                ],
+            ]
+        ]
+    ];
+
+    public function __construct($featureList = [], $feature = [])
+    {
+        $this->feature = empty($feature) ? $this::$normalFeature : $feature;
+        $this->featureList = empty($featureList) ? $this::$featureListWithNormalFields : $featureList;
+    }
+
     public function retrieve(string $id, array $headers = []): RetrieveFeatureResponse
     {
         return RetrieveFeatureResponse::from([
@@ -58,80 +165,7 @@ class FeatureActionsFixture implements FeatureActionsInterface
 
     public function all(array $params = [], array $headers = []): ListFeatureResponse
     {
-        $features = ListFeatureResponse::from([
-            'list' => [
-                [
-                    'feature' => [
-                        'id' => 'feature_free_trial',
-                        'name' => 'Free Trial',
-                        'description' => 'Gives 14 days of free trial access',
-                        'unit' => 'days',
-                        'resource_version' => 1,
-                        'updated_at' => 1690999999,
-                        'created_at' => 1690000000,
-                        'levels' => [],
-                        'status' => 'active',
-                        'type' => 'limit',
-                    ],
-                ],
-                [
-                    'feature' => [
-                        'id' => 'feature_priority_support',
-                        'name' => 'Priority Support',
-                        'description' => '24/7 support',
-                        'unit' => null,
-                        'resource_version' => 2,
-                        'updated_at' => 1691999999,
-                        'created_at' => 1691000000,
-                        'levels' => [],
-                        'status' => 'archived',
-                        'type' => 'boolean',
-                    ],
-                ],
-                [
-                    'feature' => [
-                        'id' => 'check_check',
-                        'name' => 'Priority Support',
-                        'description' => '24/7 support',
-                        'unit' => null,
-                        'resource_version' => 2,
-                        'updated_at' => 1691999999,
-                        'created_at' => 1691000000,
-                        'levels' => [],
-                        'status' => 'archived',
-                        'type' => 'boolean',
-                    ],
-                ],
-                [
-                    'feature' => [
-                        'id' => '11111111',
-                        'name' => '12121212',
-                        'description' => '24/7 support',
-                        'unit' => null,
-                        'resource_version' => 2,
-                        'updated_at' => 1691999999,
-                        'created_at' => 1691000000,
-                        'levels' => [],
-                        'status' => 'archived',
-                        'type' => 'boolean',
-                    ],
-                ],
-                [
-                    'feature' => [
-                        'id' => 'some-uuid',
-                        'name' => 'myname$$$iscashier###',
-                        'description' => '24/7 support',
-                        'unit' => null,
-                        'resource_version' => 2,
-                        'updated_at' => 1691999999,
-                        'created_at' => 1691000000,
-                        'levels' => [],
-                        'status' => 'archived',
-                        'type' => 'boolean',
-                    ],
-                ],
-            ]
-        ]);
+        $features = ListFeatureResponse::from($this->featureList);
         return $features;
     }
 
@@ -157,7 +191,7 @@ class FeatureActionsFixture implements FeatureActionsInterface
 
     public function activate(string $id, array $headers = []): ActivateFeatureResponse
     {
-        return  ActivateFeatureResponse::from($this->feature);
+        return ActivateFeatureResponse::from($this->feature);
     }
 
     public function reactivate(string $id, array $headers = []): ReactivateFeatureResponse

--- a/tests/Fixtures/FeatureActionsFixture.php
+++ b/tests/Fixtures/FeatureActionsFixture.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Chargebee\Cashier\Tests\Fixtures;
+
+use Chargebee\Actions\Contracts\FeatureActionsInterface;
+use Chargebee\Responses\FeatureResponse\ListFeatureResponse;
+use Chargebee\Responses\FeatureResponse\RetrieveFeatureResponse;
+use Chargebee\Responses\FeatureResponse\ReactivateFeatureResponse;
+use Chargebee\Responses\FeatureResponse\ActivateFeatureResponse;
+use Chargebee\Responses\FeatureResponse\CreateFeatureResponse;
+use Chargebee\Responses\FeatureResponse\DeleteFeatureResponse;
+use Chargebee\Responses\FeatureResponse\UpdateFeatureResponse;
+use Chargebee\Responses\FeatureResponse\ArchiveFeatureResponse;
+
+class FeatureActionsFixture implements FeatureActionsInterface
+{
+    public array $feature = [
+        'feature' => [
+            'id' => "Dummy-Feature-id",
+            'name' => 'Free Trial',
+            'description' => 'Gives 14 days of free trial access',
+            'unit' => 'days',
+            'resource_version' => 1,
+            'updated_at' => 1690999999,
+            'created_at' => 1690000000,
+            'levels' => [
+                [
+                    'name' => 'basic',
+                    'value' => '14',
+                ],
+            ],
+            'status' => 'active',
+            'type' => 'limit',
+        ],
+    ];
+    public function retrieve(string $id, array $headers = []): RetrieveFeatureResponse
+    {
+        return RetrieveFeatureResponse::from([
+            'feature' => [
+                'id' => $id,
+                'name' => 'Free Trial',
+                'description' => 'Gives 14 days of free trial access',
+                'unit' => 'days',
+                'resource_version' => 1,
+                'updated_at' => 1690999999,
+                'created_at' => 1690000000,
+                'levels' => [
+                    [
+                        'name' => 'basic',
+                        'value' => '14',
+                    ],
+                ],
+                'status' => 'active',
+                'type' => 'limit',
+            ],
+        ]);
+    }
+
+    public function all(array $params = [], array $headers = []): ListFeatureResponse
+    {
+        $features = ListFeatureResponse::from([
+            'list' => [
+                [
+                    'feature' => [
+                        'id' => 'feature_free_trial',
+                        'name' => 'Free Trial',
+                        'description' => 'Gives 14 days of free trial access',
+                        'unit' => 'days',
+                        'resource_version' => 1,
+                        'updated_at' => 1690999999,
+                        'created_at' => 1690000000,
+                        'levels' => [],
+                        'status' => 'active',
+                        'type' => 'limit',
+                    ],
+                ],
+                [
+                    'feature' => [
+                        'id' => 'feature_priority_support',
+                        'name' => 'Priority Support',
+                        'description' => '24/7 support',
+                        'unit' => null,
+                        'resource_version' => 2,
+                        'updated_at' => 1691999999,
+                        'created_at' => 1691000000,
+                        'levels' => [],
+                        'status' => 'archived',
+                        'type' => 'boolean',
+                    ],
+                ],
+                [
+                    'feature' => [
+                        'id' => 'check_check',
+                        'name' => 'Priority Support',
+                        'description' => '24/7 support',
+                        'unit' => null,
+                        'resource_version' => 2,
+                        'updated_at' => 1691999999,
+                        'created_at' => 1691000000,
+                        'levels' => [],
+                        'status' => 'archived',
+                        'type' => 'boolean',
+                    ],
+                ],
+                [
+                    'feature' => [
+                        'id' => '11111111',
+                        'name' => '12121212',
+                        'description' => '24/7 support',
+                        'unit' => null,
+                        'resource_version' => 2,
+                        'updated_at' => 1691999999,
+                        'created_at' => 1691000000,
+                        'levels' => [],
+                        'status' => 'archived',
+                        'type' => 'boolean',
+                    ],
+                ],
+                [
+                    'feature' => [
+                        'id' => 'some-uuid',
+                        'name' => 'myname$$$iscashier###',
+                        'description' => '24/7 support',
+                        'unit' => null,
+                        'resource_version' => 2,
+                        'updated_at' => 1691999999,
+                        'created_at' => 1691000000,
+                        'levels' => [],
+                        'status' => 'archived',
+                        'type' => 'boolean',
+                    ],
+                ],
+            ],
+            'next_offset' => 'off_456',
+        ]);
+        return $features;
+    }
+
+    public function create(array $params, array $headers = []): CreateFeatureResponse
+    {
+        return CreateFeatureResponse::from($this->feature);
+    }
+
+    public function delete(string $id, array $headers = []): DeleteFeatureResponse
+    {
+        return DeleteFeatureResponse::from($this->feature);
+    }
+
+    public function update(string $id, array $params = [], array $headers = []): UpdateFeatureResponse
+    {
+        return UpdateFeatureResponse::from($this->feature);
+    }
+
+    public function archive(string $id, array $headers = []): ArchiveFeatureResponse
+    {
+        return ArchiveFeatureResponse::from($this->feature);
+    }
+
+    public function activate(string $id, array $headers = []): ActivateFeatureResponse
+    {
+        return  ActivateFeatureResponse::from($this->feature);
+    }
+
+    public function reactivate(string $id, array $headers = []): ReactivateFeatureResponse
+    {
+        return ReactivateFeatureResponse::from($this->feature);
+    }
+}

--- a/tests/Fixtures/FeatureActionsFixture.php
+++ b/tests/Fixtures/FeatureActionsFixture.php
@@ -130,8 +130,7 @@ class FeatureActionsFixture implements FeatureActionsInterface
                         'type' => 'boolean',
                     ],
                 ],
-            ],
-            'next_offset' => 'off_456',
+            ]
         ]);
         return $features;
     }


### PR DESCRIPTION
### Added atrisan command to pull a features and create a enum between the value and id.
```sh
php artisan cashier:generate-feature-enum
```

### Options 
```
--class: The enum class name
default: FeaturesMap 

--namespace: The namespace for the enum.
default: App\\Models

--path= Directory to save the enum file.
default: app/Models 

--force: Overwrite if the file already exists.
```

### Sample Output 

```php
<?php

declare(strict_types=1);

namespace App\Models;

enum FeaturesMap: string
{
    case USER_LICENSES = 'user-licenses';
    case DASHBOARD = 'dashboard';

    public static function values(): array
    {
        return array(
            0 => 'user-licenses',
            1 => 'dashboard',
        );
    }
}
```
