### PR TITLE
Releasing v1.4.0. Please review CHANGELOG.md for more details.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,16 +44,11 @@ jobs:
 
     strategy:
       max-parallel: 1
+      fail-fast: true
       matrix:
-        php: [ 8.1, 8.2, 8.3, 8.4 ]
-        laravel: [ 10, 11, 12 ]
-        exclude:
-          - php: 8.1
-            laravel: 11
-          - php: 8.1
-            laravel: 12
+        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
 
-    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout code
@@ -68,11 +63,46 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
-      - name: Install dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"
+      - name: Install dependencies (Laravel 10)
+        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^10"
+        if: matrix.php >= 8.1 && matrix.php < 8.4
 
-      - name: Execute tests
+      - name: Execute tests (Laravel 10)
         run: vendor/bin/phpunit --display-deprecations --fail-on-deprecation
+        if: matrix.php >= 8.1 && matrix.php < 8.4
+        env:
+          CHARGEBEE_SITE: ${{ vars.CHARGEBEE_SITE }}
+          CHARGEBEE_API_KEY: ${{ secrets.CHARGEBEE_API_KEY }}
+
+      - name: Install dependencies (Laravel 11)
+        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^11"
+        if: matrix.php >= 8.2 && matrix.php <= 8.4
+
+      - name: Execute tests (Laravel 11)
+        run: vendor/bin/phpunit --display-deprecations --fail-on-deprecation
+        if: matrix.php >= 8.2 && matrix.php <= 8.4
+        env:
+          CHARGEBEE_SITE: ${{ vars.CHARGEBEE_SITE }}
+          CHARGEBEE_API_KEY: ${{ secrets.CHARGEBEE_API_KEY }}
+
+      - name: Install dependencies (Laravel 12)
+        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^12"
+        if: matrix.php >= 8.2 && matrix.php <= 8.5
+
+      - name: Execute tests (Laravel 12)
+        run: vendor/bin/phpunit --display-deprecations --fail-on-deprecation
+        if: matrix.php >= 8.2 && matrix.php <= 8.5
+        env:
+          CHARGEBEE_SITE: ${{ vars.CHARGEBEE_SITE }}
+          CHARGEBEE_API_KEY: ${{ secrets.CHARGEBEE_API_KEY }}
+
+      - name: Install dependencies (Laravel 13)
+        run: composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^13"
+        if: matrix.php >= 8.3 && matrix.php <= 8.5
+
+      - name: Execute tests (Laravel 13)
+        run: vendor/bin/phpunit --display-deprecations --fail-on-deprecation
+        if: matrix.php >= 8.3 && matrix.php <= 8.5
         env:
           CHARGEBEE_SITE: ${{ vars.CHARGEBEE_SITE }}
           CHARGEBEE_API_KEY: ${{ secrets.CHARGEBEE_API_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Static Analysis and Tests
 on:
   push:
     branches:
-      - master
+      - main
       - "*.x"
   pull_request:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### v1.4.0 (2026-07-13)
+
+---
+
+* 🎉 Added support for **Laravel 13 / Illuminate 13** (`illuminate/*` now allows `^10.0|^11.0|^12.0|^13.0`). No breaking changes — Laravel 10, 11 and 12 remain supported and the minimum PHP version stays `^8.1`.
+* Bumped `orchestra/testbench` to `^8.36|^9.15|^10.8|^11.0` and `dompdf/dompdf` to `^2.0|^3.0`; PHPUnit is now resolved via Testbench.
+* Updated the CI matrix to test PHP 8.1–8.5 against Laravel 10, 11, 12 and 13.
+
+
 ### v1.3.0 (2026-02-11)
 
 ---

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,18 @@
     "require": {
         "php": "^8.1",
         "chargebee/chargebee-php": "^4.8.0",
-        "illuminate/database": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "moneyphp/money": "^4.0"
     },
     "require-dev": {
-        "dompdf/dompdf": "^2.0",
+        "dompdf/dompdf": "^2.0|^3.0",
         "laravel/pint": "^1.22",
-        "orchestra/testbench": "^8.18 || ^9.0",
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^10.4"
+        "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+        "phpstan/phpstan": "^1.10"
     },
     "suggest": {
-        "dompdf/dompdf": "Required when generating and downloading invoice PDF's using Dompdf (^1.0.1 || ^2.0)."
+        "dompdf/dompdf": "Required when generating and downloading invoice PDF's using Dompdf (^2.0|^3.0)."
     },
     "prefer-stable": true,
     "autoload": {

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -26,7 +26,7 @@ final class Cashier
      *
      * @var string
      */
-    public const VERSION = '1.3.0';
+    public const VERSION = '1.4.0';
 
     /**
      * The custom currency formatter.

--- a/tests/Unit/InvoiceLineItemTest.php
+++ b/tests/Unit/InvoiceLineItemTest.php
@@ -50,7 +50,7 @@ class InvoiceLineItemTest extends TestCase
 
         $item = new InvoiceLineItem($invoice, $chargebeeInvoiceLineItem);
         $result = $item->inclusiveTaxPercentage();
-        $this->assertSame(20, $result);
+        $this->assertSame(20.0, $result);
     }
 
     public function test_we_can_calculate_the_exclusive_tax_percentage()
@@ -90,7 +90,7 @@ class InvoiceLineItemTest extends TestCase
 
         $item = new InvoiceLineItem($invoice, $chargebeeInvoiceLineItem);
         $result = $item->exclusiveTaxPercentage();
-        $this->assertSame(20, $result);
+        $this->assertSame(20.0, $result);
     }
 
     public function test_can_get_period()


### PR DESCRIPTION
### v1.4.0 (2026-07-13)

---

* 🎉 Added support for **Laravel 13 / Illuminate 13** (`illuminate/*` now allows `^10.0|^11.0|^12.0|^13.0`). No breaking changes — Laravel 10, 11 and 12 remain supported and the minimum PHP version stays `^8.1`.
* Bumped `orchestra/testbench` to `^8.36|^9.15|^10.8|^11.0` and `dompdf/dompdf` to `^2.0|^3.0`; PHPUnit is now resolved via Testbench.
* Updated the CI matrix to test PHP 8.1–8.5 against Laravel 10, 11, 12 and 13. 

Resolves: #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Releases v1.4.0 adding Laravel/Illuminate 13 support (incl. composer constraints), keeps Laravel 10–12 and PHP ^8.1. Updates orchestra/testbench and dompdf/dompdf compatibility, adjusts CI to test PHP 8.1–8.5 across Laravel 10–13, bumps Cashier version, and fixes invoice tax percentage assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->